### PR TITLE
Add root path to sys.path before tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
-import os
+import sys, os
 import contextlib
+
+testPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, testPath + '/../')
 
 import pytest
 


### PR DESCRIPTION
- Tests were unable to find the `src` module
- It was not an issue on my local machine because I had run `pip install -e`. This seems unnecessary for this project.
- Solution https://stackoverflow.com/a/10253916/9216668
![Screen Shot 2021-06-16 at 1 46 32 PM](https://user-images.githubusercontent.com/22715889/122267858-60936780-cea9-11eb-8a65-cc35cb1e108b.jpeg)
